### PR TITLE
chore: patch to use main branch of iroh dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ n0-future = "0.1.2"
 [features]
 # generate headers
 headers = ["safer-ffi/headers"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }


### PR DESCRIPTION
This PR updates the following dependencies to use their main branches:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`