### PR TITLE
feat!: add `endpoint_config_enable_tls_x509`

### DIFF
--- a/irohnet.h
+++ b/irohnet.h
@@ -421,6 +421,9 @@ typedef struct Vec_Vec_uint8 {
  */
 typedef struct SecretKey SecretKey_t;
 
+
+#include <stdbool.h>
+
 /** \brief
  *  Configuration options for the Endpoint.
  */
@@ -436,6 +439,9 @@ typedef struct EndpointConfig {
 
     /** <No documentation available> */
     SecretKey_t * secret_key;
+
+    /** <No documentation available> */
+    bool tls_x509;
 } EndpointConfig_t;
 
 /** \brief
@@ -497,6 +503,14 @@ endpoint_config_add_secret_key (
  */
 EndpointConfig_t
 endpoint_config_default (void);
+
+/** \brief
+ *  Enables X.509 TLS certificates for backwards compatibility with versions of
+ *  `iroh` from `0.33.0` and earlier
+ */
+void
+endpoint_config_enable_tls_x509 (
+    EndpointConfig_t * config);
 
 /** \brief
  *  Frees the iroh endpoint config.


### PR DESCRIPTION
Add option to enable X.509 TLS certificates. The default is Raw Public Keys. Endpoints that use one kind of cert cannot communicate with endpoints using the other, so this is a breaking change.