### PR TITLE
chore: update to iroh 0.35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
             components: rustfmt
 
         - name: Install sccache
-          uses: mozilla-actions/sccache-action@v0.0.3
+          uses: mozilla-actions/sccache-action@v0.0.8
 
         - name: fmt
           run: cargo fmt --all -- --check
@@ -402,7 +402,7 @@ jobs:
         - uses: actions/checkout@master
         - uses: dtolnay/rust-toolchain@stable
         - name: Install sccache
-          uses: mozilla-actions/sccache-action@v0.0.3
+          uses: mozilla-actions/sccache-action@v0.0.8
 
         # TODO: We have a bunch of platform-dependent code so should
         #    probably run this job on the full platform matrix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-c-ffi"
-version = "0.33.0"
+version = "0.35.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
@@ -19,8 +19,8 @@ required-features = ["headers"]  # Do not build unless generating headers.
 [dependencies]
 anyhow = "1.0.79"
 bytes = "1.5.0"
-iroh = { version = "0.34", features = ["discovery-local-network"] }
-iroh-base = { version = "0.34", features = ["ticket"] }
+iroh = { version = "0.35", features = ["discovery-local-network"] }
+iroh-base = { version = "0.35", features = ["ticket"] }
 once_cell = "1.19.0"
 rand = "0.8.5"
 safer-ffi = { version = "0.1.5" }
@@ -34,7 +34,3 @@ n0-future = "0.1.2"
 [features]
 # generate headers
 headers = ["safer-ffi/headers"]
-
-[patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ n0-future = "0.1.2"
 [features]
 # generate headers
 headers = ["safer-ffi/headers"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,29 +1,42 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0436",
+]
+
 [bans]
+deny = [
+    "aws-lc",
+    "aws-lc-rs",
+    "aws-lc-sys",
+    "native-tls",
+    "openssl",
+]
 multiple-versions = "allow"
 
 [licenses]
 allow = [
-      "Apache-2.0",
-      "Apache-2.0 WITH LLVM-exception",
-      "BSD-2-Clause",
-      "BSD-3-Clause",
-      "BSL-1.0", # BOSL license
-      "ISC",
-      "MIT",
-      "OpenSSL",
-      "Unicode-DFS-2016",
-      "Zlib",
-      "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
-      "Unicode-3.0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "Zlib",
+    "Unicode-3.0",
+    "MPL-2.0",
+    "Unlicense",
 ]
 
 [[licenses.clarify]]
-name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-      { path = "LICENSE", hash = 0xbd0eed23 },
-]
+name = "ring"
 
-[advisories]
-ignore = [
-]
+[[licenses.clarify.license-files]]
+hash = 3171872035
+path = "LICENSE"
+
+[sources]
+allow-git = []


### PR DESCRIPTION
This PR updates the following dependencies:

- `iroh` to 0.35
- `iroh-base` to 0.35

Bumps the version number of `iroh-c-ffi` to 0.35