### PR TITLE
ci: add semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,3 +423,35 @@ jobs:
 
         - name: clippy check (default features)
           run: cargo clippy --workspace --all-targets
+
+    check_semver:
+        timeout-minutes: 30
+        name: Check semver
+        runs-on: ubuntu-latest
+        env:
+            RUSTC_WRAPPER: "sccache"
+            SCCACHE_GHA_ENABLED: "on"
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Install sccache
+              uses: mozilla-actions/sccache-action@v0.0.9
+
+            - name: Setup Environment (PR)
+              if: ${{ github.event_name == 'pull_request' }}
+              shell: bash
+              run: |
+                  echo "HEAD_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})" >> ${GITHUB_ENV}
+            - name: Setup Environment (Push)
+              if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
+              shell: bash
+              run: |
+                  echo "HEAD_COMMIT_SHA=$(git rev-parse origin/main)" >> ${GITHUB_ENV}
+            - name: Check semver
+              # uses: obi1kenobi/cargo-semver-checks-action@v2
+              uses: n0-computer/cargo-semver-checks-action@feat-baseline
+              with:
+                  package: iroh-c-ffi
+                  baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
+                  use-cache: false


### PR DESCRIPTION
Adds a check_semver CI job using n0-computer/cargo-semver-checks-action, matching the setup used across the iroh ecosystem.